### PR TITLE
Maze objects now track their start and finish cells

### DIFF
--- a/VR Maze/Assets/Editor/MazeTests.cs
+++ b/VR Maze/Assets/Editor/MazeTests.cs
@@ -100,5 +100,87 @@ namespace Assets.Scripts.Tests {
             Assert.IsTrue(maze.ContainsCell(new MazeCell(2, 3, false, false)));
             Assert.IsTrue(maze.ContainsCell(new MazeCell(3, 3, false, false)));
         }
+
+        [Test]
+        public void MazeTests_StartCellTest()
+        {
+            MazeGenerator generator = new HardcodedTestMazeGenerator();
+            Maze maze = generator.Generate();
+            Assert.IsNull(maze.StartCell);
+            maze.StartCell = new Pair<int, int>(1, 1);
+            Assert.AreEqual(maze.StartCell, new Pair<int, int>(1, 1));
+            maze.StartCell = new Pair<int, int>(2, 3);
+            Assert.AreEqual(maze.StartCell, new Pair<int, int>(2, 3));
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void MazeTests_StartCellInMaze()
+        {
+            MazeGenerator generator = new HardcodedTestMazeGenerator();
+            Maze maze = generator.Generate();
+            maze.StartCell = new Pair<int, int>(4, 4);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void MazeTests_FinishCellInMaze()
+        {
+            MazeGenerator generator = new HardcodedTestMazeGenerator();
+            Maze maze = generator.Generate();
+            maze.FinishCell = new Pair<int, int>(4, 4);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void MazeTests_StartCellNotFinishCell()
+        {
+            MazeGenerator generator = new HardcodedTestMazeGenerator();
+            Maze maze = generator.Generate();
+            maze.FinishCell = new Pair<int, int>(1, 1);
+            maze.StartCell = new Pair<int, int>(1, 1);
+        }
+
+        [Test]
+        [ExpectedException(typeof(ArgumentException))]
+        public void MazeTests_FinishCellNotStartCell()
+        {
+            MazeGenerator generator = new HardcodedTestMazeGenerator();
+            Maze maze = generator.Generate();
+            maze.StartCell = new Pair<int, int>(1, 1);
+            maze.FinishCell = new Pair<int, int>(1, 1);
+        }
+
+        [Test]
+        public void MazeTests_FinishCellTest()
+        {
+            MazeGenerator generator = new HardcodedTestMazeGenerator();
+            Maze maze = generator.Generate();
+            Assert.IsNull(maze.FinishCell);
+            maze.FinishCell = new Pair<int, int>(1, 1);
+            Assert.AreEqual(maze.FinishCell, new Pair<int, int>(1, 1));
+            maze.FinishCell = new Pair<int, int>(2, 3);
+            Assert.AreEqual(maze.FinishCell, new Pair<int, int>(2, 3));
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void MazeTests_MazeWithoutStartNotDrawable()
+        {
+            MazeGenerator generator = new HardcodedTestMazeGenerator();
+            Maze maze = generator.Generate();
+            maze.FinishCell = new Pair<int, int>(1, 1);
+            maze.Draw();
+        }
+
+        [Test]
+        [ExpectedException(typeof(InvalidOperationException))]
+        public void MazeTests_MazeWithoutFinishNotDrawable()
+        {
+            MazeGenerator generator = new HardcodedTestMazeGenerator();
+            Maze maze = generator.Generate();
+            maze.StartCell = new Pair<int, int>(1, 1);
+            maze.Draw();
+        }
     }
 }

--- a/VR Maze/Assets/Editor/RandomMazeGeneratorTests.cs
+++ b/VR Maze/Assets/Editor/RandomMazeGeneratorTests.cs
@@ -12,9 +12,9 @@ namespace Assets.Scripts.Tests
             RandomMazeGenerator generator = new RandomMazeGenerator(5, 6);
             RandomMaze maze = generator.Generate() as RandomMaze;
             Assert.AreEqual(maze.Graph.Count, 30);
-            for(int i = 0; i < 5; i++)
+            for (int i = 0; i < 5; i++)
             {
-                for(int j = 0; j < 6; j++)
+                for (int j = 0; j < 6; j++)
                 {
                     Assert.IsTrue(maze.Graph.Contains(new Pair<int, int>(j, i)), i + ", " + j);
                 }
@@ -26,11 +26,27 @@ namespace Assets.Scripts.Tests
         {
             RandomMazeGenerator generator = new RandomMazeGenerator(5, 6);
             RandomMaze maze = generator.Generate() as RandomMaze;
-            foreach(var node in maze.Graph)
+            foreach (var node in maze.Graph)
             {
                 Assert.IsTrue(maze.Graph.Neighbors(node).Count > 0);
                 Assert.IsTrue(maze.Graph.Neighbors(node).Count < 5);
             }
+        }
+
+        [Test]
+        public void RandomMazeGeneratorTests_StartCellUpperLeft()
+        {
+            RandomMazeGenerator generator = new RandomMazeGenerator(5, 6);
+            Maze maze = generator.Generate();
+            Assert.AreEqual(maze.StartCell, new Pair<int, int>(0, 0));
+        }
+
+        [Test]
+        public void RandomMazeGeneratorTests_FinishCellBottomRight()
+        {
+            RandomMazeGenerator generator = new RandomMazeGenerator(5, 6);
+            Maze maze = generator.Generate();
+            Assert.AreEqual(maze.FinishCell, new Pair<int, int>(4, 5));
         }
     }
 }

--- a/VR Maze/Assets/Scripts/Maze.cs
+++ b/VR Maze/Assets/Scripts/Maze.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -14,6 +15,8 @@ namespace Assets.Scripts
         private Vector3 ThisMazePosition;
         private MazeDrawer Drawer;
         private string mazeName;
+        private MazeCell startCell;
+        private MazeCell finishCell;
 
         /// <summary>
         /// Intializes the maze
@@ -62,6 +65,62 @@ namespace Assets.Scripts
         }
 
         /// <summary>
+        /// Gets and sets the start cell of the maze, in the form of a pair of ints representing the X and Z coordinates of the cell.
+        /// </summary>
+        public Pair<int, int> StartCell
+        {
+            get
+            {
+                if (startCell == null)
+                {
+                    return null;
+                }
+                return new Pair<int, int>(startCell.cellLocationX, startCell.cellLocationZ);
+            }
+            set
+            {
+                MazeCell cell = FindCellByCoordinates(value.First, value.Second);
+                if (cell == null)
+                {
+                    throw new ArgumentException("The given cell is not in the maze.");
+                }
+                if (cell.Equals(finishCell))
+                {
+                    throw new ArgumentException("The start cell cannot be the same as the finish cell.");
+                }
+                startCell = cell;
+            }
+        }
+
+        /// <summary>
+        /// Gets and sets the finish cell of the maze, in the form of a pair of ints representing the X and Z coordinates of the cell.
+        /// </summary>
+        public Pair<int, int> FinishCell
+        {
+            get
+            {
+                if(finishCell == null)
+                {
+                    return null;
+                }
+                return new Pair<int, int>(finishCell.cellLocationX, finishCell.cellLocationZ);
+            }
+            set
+            {
+                MazeCell cell = FindCellByCoordinates(value.First, value.Second);
+                if (cell == null)
+                {
+                    throw new ArgumentException("The given cell is not in the maze.");
+                }
+                if (cell.Equals(startCell))
+                {
+                    throw new ArgumentException("The finish cell cannot be the same as the start cell.");
+                }
+                finishCell = cell;
+            }
+        }
+
+        /// <summary>
         /// Allows Maze Scale to be change in the X,Y, and Z directions
         /// </summary>
         /// <param name="x"> x scale multiplier</param>
@@ -86,6 +145,24 @@ namespace Assets.Scripts
         }
 
         /// <summary>
+        /// Given coordinates, finds the corresponding MazeCell object if it exists.
+        /// </summary>
+        /// <param name="x">The x coordinate of the cell</param>
+        /// <param name="z">The z coordinate of the cell</param>
+        /// <returns>The cell, if it exists, or null otherwise</returns>
+        private MazeCell FindCellByCoordinates(int x, int z)
+        {
+            foreach(var cell in CellsInMaze)
+            {
+                if (cell.cellLocationX == x && cell.cellLocationZ == z)
+                {
+                    return cell;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
         /// Sets XYZ Position of the maze
         /// </summary>
         /// <param name="x"> x position</param>
@@ -101,6 +178,14 @@ namespace Assets.Scripts
         /// </summary>
         public void Draw()
         {
+            if (startCell == null)
+            {
+                throw new InvalidOperationException("The maze has no defined start cell.");
+            }
+            if (finishCell == null)
+            {
+                throw new InvalidOperationException("The maze has no defined finish cell.");
+            }
             Drawer = new MazeDrawer(this);
             Drawer.drawMaze();
             ThisMaze.transform.localScale = ThisMazeScale;

--- a/VR Maze/Assets/Scripts/MazeCell.cs
+++ b/VR Maze/Assets/Scripts/MazeCell.cs
@@ -12,8 +12,6 @@ namespace Assets.Scripts
     public class MazeCell
     {
         public GameObject mazeCellGO;
-        private bool startCell;
-        private bool finishCell;
         private bool southPath;
         private bool eastPath;
         private int[] cellLocation = new int[2];
@@ -27,8 +25,6 @@ namespace Assets.Scripts
             eastPath = EastPath;
             cellLocation[0] = x;
             cellLocation[1] = z;
-            startCell = false;
-            finishCell = false;
         }
 
         /// <summary>
@@ -59,34 +55,6 @@ namespace Assets.Scripts
             {
                 cellLocation[1] = cellLocationZ;
             }
-        }
-
-        /// <summary>
-        /// Get and set method for StartCell
-        /// </summary>
-        public bool StartCell
-        {
-            get
-            {
-                return startCell;
-            }
-            set
-            {
-                startCell = StartCell;
-            }
-        }
-
-        public bool FinishCell
-        {
-            get
-            {
-                return startCell;
-            }
-            set
-            {
-                finishCell = FinishCell;
-            }
-
         }
 
         /// <summary>
@@ -131,8 +99,7 @@ namespace Assets.Scripts
             {
                 return false;
             }
-            return (this.startCell == cell.StartCell) && (this.finishCell == cell.finishCell)
-                && (this.southPath == cell.southPath) && (this.eastPath == cell.eastPath)
+            return (this.southPath == cell.southPath) && (this.eastPath == cell.eastPath)
                 && (this.cellLocationX == cell.cellLocationX) && (this.cellLocationZ == cell.cellLocationZ);
         }
         

--- a/VR Maze/Assets/Scripts/RandomMazeGenerator.cs
+++ b/VR Maze/Assets/Scripts/RandomMazeGenerator.cs
@@ -24,6 +24,8 @@ namespace Assets.Scripts
             UndirectedGraph<Pair<int, int>> graph = CreateUnconnectedGridGraph(this.width, this.height);
             graph = BuildRandomGridSpanningTree(graph);
             RandomMaze maze = new RandomMaze(graph);
+            maze.StartCell = new Pair<int, int>(0, 0);
+            maze.FinishCell = new Pair<int, int>(width - 1, height - 1);
             return maze;
         }
 

--- a/VR Maze/Assets/Scripts/TestMaze.cs
+++ b/VR Maze/Assets/Scripts/TestMaze.cs
@@ -48,6 +48,9 @@ namespace Assets.Scripts
             addMazeCell(2, 4, true, true);
             addMazeCell(3, 4, true, false);
             addMazeCell(4, 4, true, true);
+
+            this.StartCell = new Pair<int, int>(0, 0);
+            this.FinishCell = new Pair<int, int>(4, 4);
         }
     }
 


### PR DESCRIPTION
Mazes track start and finish cells. Added an interface for accessing and modifying these.
Mazes now cannot be drawn without defined start and finish cells.
Added tests for all of the above.