### PR TITLE
Time Trial Maze Generation

### DIFF
--- a/VR Maze/Assets/Scripts/RandomMazeGenerator.cs
+++ b/VR Maze/Assets/Scripts/RandomMazeGenerator.cs
@@ -12,11 +12,20 @@ namespace Assets.Scripts
     {
         private int width;
         private int height;
+        private int seed;
 
         public RandomMazeGenerator(int width, int height)
         {
             this.width = width;
             this.height = height;
+            this.seed = System.DateTime.Now.Millisecond;
+        }
+
+        public RandomMazeGenerator(int width, int height, int seed)
+        {
+            this.width = width;
+            this.height = height;
+            this.seed = seed;
         }
 
         public override Maze Generate()
@@ -58,10 +67,10 @@ namespace Assets.Scripts
             var startCell = new Pair<int, int>(0, 0);
             List<Pair<int, int>> inMaze = new List<Pair<int, int>>();
             inMaze.Add(startCell);
+            var random = new Random(this.seed);
             while (inMaze.Count < graph.Count)
             {
                 List<GridEdge> candidateEdges = FindCandidateEdges(graph, inMaze);
-                var random = new Random();
                 int chosenIndex = random.Next(candidateEdges.Count);
                 graph.AddEdge(candidateEdges[chosenIndex].Cell1, candidateEdges[chosenIndex].Cell2);
                 inMaze.Add(candidateEdges[chosenIndex].Cell2);
@@ -134,6 +143,14 @@ namespace Assets.Scripts
 
             public Pair<int, int> Cell1{get; set;}
             public Pair<int, int> Cell2 { get; set; }
+        }
+
+        public int Seed
+        {
+            get
+            {
+                return this.seed;
+            }
         }
     }
 }

--- a/VR Maze/Assets/Scripts/TimeTrialMaze.cs
+++ b/VR Maze/Assets/Scripts/TimeTrialMaze.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Assets.Scripts
+{
+    /// <summary>
+    /// Generates mazes for the Time Trials gamemode
+    /// </summary>
+    public class TimeTrialMazeGenerator : MazeGenerator
+    {
+        public override Maze Generate()
+        {
+            Random rng = new Random();
+            int map = rng.Next(1, 3);
+            int seed;
+            switch (map)
+            {
+                case 1:
+                    seed = 640;
+                    break;
+                case 2:
+                    seed = 409;
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException("The generator tried to generate map number " + map + ", which does not exist.");
+            }
+            MazeGenerator generator = new RandomMazeGenerator(15, 15, seed);
+            return generator.Generate();
+        }
+    }
+}

--- a/VR Maze/Assets/Scripts/TimeTrialMaze.cs.meta
+++ b/VR Maze/Assets/Scripts/TimeTrialMaze.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f06971c012251124e88fe90b7e18995f
+timeCreated: 1491453000
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
-Modified the RandomMazeGenerator class to use controllable seeding
-Found two seeds that produce seemingly good looking time trials mazes
-Created the TimeTrialsMazeGenerator class, a MazeGenerator class that produces one of the above mazes, chosen at random. 

Currently only contains two mazes, but new seeds are extremely easy to add.

To add seeds of your own to the pool, simply add a case switch statement, input your seed, and expand the range of the rng accordingly.

(This also removes unnecessary repeated initializations of the Random class, which actually shortens our load time for the FreeRoam scene! Pretty neat side effect.)