### PR TITLE
[DevTool] Added readonly script properties to Unity

### DIFF
--- a/VR Maze/Assets/Editor/ReadOnlyDrawer.cs
+++ b/VR Maze/Assets/Editor/ReadOnlyDrawer.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using Assets.EditorTools;
+
+/// <summary>
+/// Unity Editor property drawer for ReadOnly properties
+/// </summary>
+[CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
+public class ReadOnlyDrawer : PropertyDrawer
+{
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property, label, true);
+    }
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        GUI.enabled = false;
+        EditorGUI.PropertyField(position, property, label, true);
+        GUI.enabled = true;
+    }
+}

--- a/VR Maze/Assets/Editor/ReadOnlyDrawer.cs.meta
+++ b/VR Maze/Assets/Editor/ReadOnlyDrawer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 58848438e22955f49b539d513e891cc2
+timeCreated: 1493259300
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/VR Maze/Assets/Scripts/ReadOnlyAttribute.cs
+++ b/VR Maze/Assets/Scripts/ReadOnlyAttribute.cs
@@ -5,8 +5,14 @@ using UnityEditor;
 
 namespace Assets.EditorTools
 {
+    /// <summary>
+    /// Makes a public property readonly in the Unity editor
+    /// </summary>
     public class ReadOnlyAttribute : PropertyAttribute { };
 
+    /// <summary>
+    /// Unity Editor property drawer for ReadOnly properties
+    /// </summary>
     [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
     public class ReadOnlyDrawer : PropertyDrawer
     {

--- a/VR Maze/Assets/Scripts/ReadOnlyAttribute.cs
+++ b/VR Maze/Assets/Scripts/ReadOnlyAttribute.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEditor;
 
 namespace Assets.EditorTools
 {
@@ -9,23 +8,4 @@ namespace Assets.EditorTools
     /// Makes a public property readonly in the Unity editor
     /// </summary>
     public class ReadOnlyAttribute : PropertyAttribute { };
-
-    /// <summary>
-    /// Unity Editor property drawer for ReadOnly properties
-    /// </summary>
-    [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
-    public class ReadOnlyDrawer : PropertyDrawer
-    {
-        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
-        {
-            return EditorGUI.GetPropertyHeight(property, label, true);
-        }
-
-        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
-        {
-            GUI.enabled = false;
-            EditorGUI.PropertyField(position, property, label, true);
-            GUI.enabled = true;
-        }
-    }
 }

--- a/VR Maze/Assets/Scripts/ReadOnlyAttribute.cs
+++ b/VR Maze/Assets/Scripts/ReadOnlyAttribute.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+namespace Assets.EditorTools
+{
+    public class ReadOnlyAttribute : PropertyAttribute { };
+
+    [CustomPropertyDrawer(typeof(ReadOnlyAttribute))]
+    public class ReadOnlyDrawer : PropertyDrawer
+    {
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(property, label, true);
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            GUI.enabled = false;
+            EditorGUI.PropertyField(position, property, label, true);
+            GUI.enabled = true;
+        }
+    }
+}

--- a/VR Maze/Assets/Scripts/ReadOnlyAttribute.cs.meta
+++ b/VR Maze/Assets/Scripts/ReadOnlyAttribute.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 043b8735fb4db05488f430bd0d963d39
+timeCreated: 1493254983
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This is a development tool which modifies the Unity editor, not the project itself.
This allows developers to make a script property readonly, in case a property needs to be read but not written to.

Here's how to use it:
~~~~
using Assets.EditorTools;

public class MyScript : MonoBehaviour {

    public string editable;  //This property can be read and changed in the Unity editor

    [ReadOnly]
    public string nonEditable = "asdf";  //This property can be read but *not* changed in the Unity editor

    ...
}
~~~~

And the result is:
![readonly_unity_property](https://cloud.githubusercontent.com/assets/8410871/25455065/2835e434-2a94-11e7-863c-5beed1620147.png)
